### PR TITLE
WHM 54.0 (build 21) compatabillity

### DIFF
--- a/acctinfo
+++ b/acctinfo
@@ -1232,7 +1232,7 @@ sub get_system_php_version() {
 	my $phpDefault = "";
 	foreach $phpconfline(@PHPCONF) { 
 		chomp($phpconfline);
-		if ($phpconfline =~ m/as the system default/) { 
+		if ($phpconfline =~ m/default/) { 
 			($phpDefault)=(split(/\s+/,$phpconfline))[2];
 		}
 	}


### PR DESCRIPTION
EA4 on WHM 54.0 (build 21) changes that string to 

>  Setting ea-php56 as default 

So, I would just look for the word default.